### PR TITLE
Add create ecs cluster

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -20,6 +20,7 @@ resource "aws_launch_configuration" "lc" {
   security_groups      = ["${var.security_groups}"]
   user_data            = "${var.user_data != "false" ? var.user_data : data.template_file.user_data.rendered}"
   key_name             = "${var.ssh_key_name}"
+  spot_price           = "${var.spot_price}"
 
   root_block_device {
     volume_size = "${var.root_volume_size}"

--- a/ecs.tf
+++ b/ecs.tf
@@ -64,6 +64,12 @@ variable "cluster_name" {}
 
 // Optional:
 
+variable "spot_price" {
+  type = "string"
+  default = ""
+  description = "(Optional) The price to use for reserving spot instances. Will use on-demand instances if empty."
+}
+
 variable "ecsInstanceRoleAssumeRolePolicy" {
   type = "string"
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -15,6 +15,7 @@ data "aws_ami" "ecs_ami" {
  * Create ECS cluster
  */
 resource "aws_ecs_cluster" "ecs_cluster" {
+  count = "${var.create_ecs_cluster ? 1 : 0}"
   name = "${var.cluster_name}"
 }
 
@@ -65,9 +66,15 @@ variable "cluster_name" {}
 // Optional:
 
 variable "spot_price" {
-  type = "string"
-  default = ""
+  type        = "string"
+  default     = ""
   description = "(Optional) The price to use for reserving spot instances. Will use on-demand instances if empty."
+}
+
+variable "create_ecs_cluster" {
+  type        = "string"
+  default     = "1"
+  description = "(Optional) A flag if ECS cluster should be created within the module or reference external one by name. (Default: 1)"
 }
 
 variable "ecsInstanceRoleAssumeRolePolicy" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,11 +15,11 @@ output "ecs_ami_id" {
 }
 
 output "ecs_cluster_id" {
-  value = "${aws_ecs_cluster.ecs_cluster.id}"
+  value = "${ join("", aws_ecs_cluster.ecs_cluster.*.id) }"
 }
 
 output "ecs_cluster_name" {
-  value = "${aws_ecs_cluster.ecs_cluster.name}"
+  value = "${ join("", aws_ecs_cluster.ecs_cluster.*.name) }"
 }
 
 output "ecs_instance_profile_id" {


### PR DESCRIPTION
Add an option to skip creation of a new ECS cluster within a module to be able to run multiple autoscaling groups with a single (created outside the module) ECS cluster. 