### PR TITLE
Release 3.0.0 - convert to launch template

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -60,6 +60,26 @@ resource "aws_autoscaling_group" "asg" {
     }
   }
 
+  dynamic "tag" {
+    for_each = var.tags_propagated
+
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  dynamic "tag" {
+    for_each = var.tags_not_propagated
+
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false
+    }
+  }
+
   protect_from_scale_in = var.protect_from_scale_in
 
   lifecycle {

--- a/asg.tf
+++ b/asg.tf
@@ -60,26 +60,6 @@ resource "aws_autoscaling_group" "asg" {
     }
   }
 
-  dynamic "tag" {
-    for_each = var.tags_propagated
-
-    content {
-      key                 = tag.key
-      value               = tag.value
-      propagate_at_launch = true
-    }
-  }
-
-  dynamic "tag" {
-    for_each = var.tags_not_propagated
-
-    content {
-      key                 = tag.key
-      value               = tag.value
-      propagate_at_launch = false
-    }
-  }
-
   protect_from_scale_in = var.protect_from_scale_in
 
   lifecycle {

--- a/asg.tf
+++ b/asg.tf
@@ -19,7 +19,7 @@ resource "aws_launch_template" "lt" {
   image_id               = data.aws_ami.ecs_ami.id
   instance_type          = var.instance_type
   key_name               = var.ssh_key_name
-  vpc_security_group_ids = var.security_groups
+  vpc_security_group_ids = var.security_group_ids
   user_data              = base64encode(var.user_data != "false" ? var.user_data : template_file(user_data, {}))
 
   iam_instance_profile {

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,8 +6,8 @@ output "asg_arn" {
   value = aws_autoscaling_group.asg.arn
 }
 
-output "asg_launch_configuration" {
-  value = aws_autoscaling_group.asg.launch_configuration
+output "asg_launch_template_id" {
+  value = aws_launch_template.lt.id
 }
 
 output "ecs_ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@
  */
 
 // Required:
-variable "security_groups" {
-  description = "List of security groups to place instances into"
+variable "security_group_ids" {
+  description = "List of security group IDs to place instances into"
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,18 @@ variable "tags" {
   ]
 }
 
+variable "tags_propagated" {
+  type        = map(string)
+  description = "Map of tags propagated at launch"
+  default     = {}
+}
+
+variable "tags_not_propagated" {
+  type        = map(string)
+  description = "Map of tags not propagated at launch"
+  default     = {}
+}
+
 variable "scaling_adjustment_up" {
   default     = "1"
   description = "How many instances to scale up by when triggered"

--- a/variables.tf
+++ b/variables.tf
@@ -71,18 +71,6 @@ variable "tags" {
   ]
 }
 
-variable "tags_propagated" {
-  type        = map(string)
-  description = "Map of tags propagated at launch"
-  default     = {}
-}
-
-variable "tags_not_propagated" {
-  type        = map(string)
-  description = "Map of tags not propagated at launch"
-  default     = {}
-}
-
 variable "scaling_adjustment_up" {
   default     = "1"
   description = "How many instances to scale up by when triggered"

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "protect_from_scale_in" {
 
 variable "tags" {
   type        = map(string)
-  description = "map of tags to add to the ASG"
+  description = "map of tags to add to created resources"
 
   default = {
     managed_by = "terraform"

--- a/variables.tf
+++ b/variables.tf
@@ -24,10 +24,6 @@ variable "user_data" {
   default     = "false"
 }
 
-variable "root_volume_size" {
-  default = "8"
-}
-
 variable "min_size" {
   default = "1"
 }
@@ -59,16 +55,12 @@ variable "protect_from_scale_in" {
 }
 
 variable "tags" {
-  type        = list(object({ key = string, value = string, propagate_at_launch = bool }))
-  description = "List of maps with keys: 'key', 'value', and 'propagate_at_launch'"
+  type        = map(string)
+  description = "map of tags to add to the ASG"
 
-  default = [
-    {
-      key                 = "created_by"
-      value               = "terraform"
-      propagate_at_launch = true
-    },
-  ]
+  default = {
+    managed_by = "terraform"
+  }
 }
 
 variable "scaling_adjustment_up" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
### Removed
- Removed launch configuration
- Removed `asg_launch_configuration` output
- Removed `root_volume_size` input

### Added
- Added launch template
- Added `asg_launch_template_id` output
- Added volume and network interface tags

### Changed (breaking)
- Changed `tags` input from a list to a map
- Changed default tag key from "created_by" to "managed_by"
- Changed minimum Terraform version to 1.0
- Renamed `security_groups` input to `security_group_ids`