### PR TITLE
Stop specifying the default Launch Template version, to allow it to be the latest one

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -11,7 +11,6 @@ locals {
  * Create Launch Template
  */
 resource "aws_launch_template" "lt" {
-  default_version = 1
   ebs_optimized   = false
   name            = "lt-${var.cluster_name}"
   image_id        = data.aws_ami.ecs_ami.id


### PR DESCRIPTION
### Fixed
- Stop specifying the default version, to allow it to be the latest one