### PR TITLE
Update the Launch Template's default version automatically

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -12,12 +12,13 @@ locals {
  * Create Launch Template
  */
 resource "aws_launch_template" "lt" {
-  ebs_optimized = false
-  name          = "lt-${var.cluster_name}"
-  image_id      = data.aws_ami.ecs_ami.id
-  instance_type = var.instance_type
-  key_name      = var.ssh_key_name
-  user_data     = base64encode(var.user_data != "false" ? var.user_data : local.user_data)
+  ebs_optimized          = false
+  name                   = "lt-${var.cluster_name}"
+  image_id               = data.aws_ami.ecs_ami.id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
+  update_default_version = true
+  user_data              = base64encode(var.user_data != "false" ? var.user_data : local.user_data)
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecsInstanceProfile.id


### PR DESCRIPTION
### Fixed
- Update the Launch Template's default version automatically
  * For docs (for the AWS provider version we currently use), see https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/launch_template#update_default_version-3

---

This relates to #21, but that change was insufficient.