### PR TITLE
remove use_amazon_linux2023 variable and simplify AMI filter for ECS

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -7,7 +7,7 @@ data "aws_ami" "ecs_ami" {
 
   filter {
     name   = "name"
-    values = var.use_amazon_linux2023 ? ["al2023-ami-ecs-hvm-*-kernel-6.1-x86_64"] : ["amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"]
+    values = ["al2023-ami-ecs-hvm-*-kernel-6.1-x86_64"]
   }
 }
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -37,7 +37,6 @@ module "full" {
   subnet_ids                      = ["subnet-01234567", "subnet-76543210"]
   tags                            = { foo : "bar" }
   termination_policies            = ["Default"]
-  use_amazon_linux2023            = true
   user_data                       = "false"
   additional_user_data            = ""
   enable_ipv6                     = true

--- a/variables.tf
+++ b/variables.tf
@@ -152,12 +152,6 @@ variable "cluster_name" {}
 
 // Optional:
 
-variable "use_amazon_linux2023" {
-  description = "Use Amazon Linux 2023 AMI"
-  type        = bool
-  default     = true
-}
-
 variable "ecsInstanceRoleAssumeRolePolicy" {
   type = string
 


### PR DESCRIPTION
### Changed

* Removed the `use_amazon_linux2023` variable from `variables.tf`, eliminating the option to select the AMI version.
* Updated the `aws_ami` data source in `ecs.tf` to always use the Amazon Linux 2023 ECS AMI filter, removing the conditional logic for Amazon Linux 2.